### PR TITLE
Implement RunningEitherT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Added `HyperFn` in `sly-lang` and these implementations:
 
 - `RunningEitherT`: EitherT<M, L, R> -> MonadRec<Either<L, R>, M>
 - `RunningMaybe`: MaybeT<M, A> -> MonadRec<Maybe<A>, M>
+- `RunningStateT`: StateT<S, M, A> -> MonadRec<Tuple2<A, S>, M>
 
 Added matchers in `sly-lambda-matchers`:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Important changes in each release of `sly` will be noted in this file.
 Added `HyperFn` in `sly-lang` and these implementations:
 
 - `RunningEitherT`: EitherT<M, L, R> -> MonadRec<Either<L, R>, M>
+- `RunningIterateT`: IterateT<M, A> -> MaybeT<M, Tuple2<A, IterateT<M, A>>>
 - `RunningMaybe`: MaybeT<M, A> -> MonadRec<Maybe<A>, M>
 - `RunningStateT`: StateT<S, M, A> -> MonadRec<Tuple2<A, S>, M>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,16 @@ Important changes in each release of `sly` will be noted in this file.
 
 Added `HyperFn` in `sly-lang` and these implementations:
 
+- `JoiningEither`: EitherT<M, L, Either<L, R>> -> EitherT<M, L, R>
+- `JoiningIdentity`: IdentityT<M, Identity<A>> -> IdentityT<M, A>
+- `JoiningMaybe`: MaybeT<M, Maybe<A>> -> MaybeT<M, A>
+- `JoiningState`: StateT<S, M, State<S, A>> -> StateT<S, M, A>
 - `RunningEitherT`: EitherT<M, L, R> -> MonadRec<Either<L, R>, M>
+- `RunningIdentityT`: IdentityT<M, A> -> MonadRec<Identity<A>, M>
 - `RunningIterateT`: IterateT<M, A> -> MaybeT<M, Tuple2<A, IterateT<M, A>>>
-- `RunningMaybe`: MaybeT<M, A> -> MonadRec<Maybe<A>, M>
+- `RunningMaybeT`: MaybeT<M, A> -> MonadRec<Maybe<A>, M>
 - `RunningStateT`: StateT<S, M, A> -> MonadRec<Tuple2<A, S>, M>
+- `RunningStreamT`: StreamT<M, A> -> MaybeT<M, Tuple2<Maybe<A>, StreamT<M, A>>>
 
 Added matchers in `sly-lambda-matchers`:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Added `HyperFn` in `sly-lang` and these implementations:
 - `RunningEitherT`: EitherT<M, L, R> -> MonadRec<Either<L, R>, M>
 - `RunningMaybe`: MaybeT<M, A> -> MonadRec<Maybe<A>, M>
 
+Added matchers in `sly-lambda-matchers`:
+
+- `Tuple2Matcher`: A matcher of `Tuple2`
+
 ## [0.1.1]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ Important changes in each release of `sly` will be noted in this file.
 
 ### Added
 
-- Added `HyperFn` in `sly-lang1
+Added `HyperFn` in `sly-lang` and these implementations:
+
+- `RunningEitherT`: EitherT<M, L, R> -> MonadRec<Either<L, R>, M>
+- `RunningMaybe`: MaybeT<M, A> -> MonadRec<Maybe<A>, M>
 
 ## [0.1.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ Important changes in each release of `sly` will be noted in this file.
 
 ## [Unreleased]
 
-No pending changes
+### Added
+
+- Added `HyperFn` in `sly-lang1
 
 ## [0.1.1]
 

--- a/lambda-matchers/src/main/java/org/movealong/sly/matchers/lambda/JustMatcher.java
+++ b/lambda-matchers/src/main/java/org/movealong/sly/matchers/lambda/JustMatcher.java
@@ -96,7 +96,7 @@ public class JustMatcher<A> extends TypeSafeDiagnosingMatcher<Maybe<A>> {
 
     /**
      * Creates a matcher that matches an instance of {@link} when the carrier
-     * is present (i.e. "just), with no other opinion about the carrier.
+     * is present (i.e. "just"), with no other opinion about the carrier.
      *
      * <pre>
      * assertThat(just("foo"), isJust()); // passes

--- a/lambda-matchers/src/main/java/org/movealong/sly/test/lambda/Tuple2Matcher.java
+++ b/lambda-matchers/src/main/java/org/movealong/sly/test/lambda/Tuple2Matcher.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.test.lambda;
+
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import lombok.AllArgsConstructor;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import static lombok.AccessLevel.PRIVATE;
+
+/**
+ * A {@link Matcher} that matches instances of {@link Tuple2}, given matchers
+ * for the elements contained in the tuple.
+ *
+ * @param <_1> the type of the first element of the tuple
+ * @param <_2> the type of the second element of the tuple
+ */
+@AllArgsConstructor(access = PRIVATE)
+public class Tuple2Matcher<_1, _2> extends TypeSafeDiagnosingMatcher<Tuple2<_1, _2>> {
+
+    private final Matcher<? super _1> _1Matcher;
+    private final Matcher<? super _2> _2Matcher;
+
+    @Override
+    protected boolean matchesSafely(Tuple2<_1, _2> item, Description mismatch) {
+        mismatch.appendText("tuple mismatch:");
+        boolean elementMatch = true;
+
+        if (!_1Matcher.matches(item._1())) {
+            _1Matcher.describeMismatch(
+                item._1(),
+                mismatch.appendText(" _1: expected ")
+                        .appendDescriptionOf(_1Matcher)
+                        .appendText(" but "));
+            elementMatch = false;
+        }
+
+        if (!_2Matcher.matches(item._2())) {
+            if (!elementMatch) {
+                mismatch.appendText(" and");
+            }
+            _2Matcher.describeMismatch(
+                item._2(),
+                mismatch.appendText(" _2: expected ")
+                        .appendDescriptionOf(_2Matcher)
+                        .appendText(" but "));
+            elementMatch = false;
+        }
+
+        return elementMatch;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description
+            .appendText("Tuple of ")
+            .appendDescriptionOf(_1Matcher)
+            .appendText(" and ")
+            .appendDescriptionOf(_2Matcher);
+    }
+
+    /**
+     * Creates a matcher that matches an instance of {@link Tuple2} when the
+     * elements of the tuple satisfy the supplied matchers.
+     *
+     * @param <_1>      the type of the first element of the tuple
+     * @param <_2>      the type of the second element of the tuple
+     * @param _1Matcher a matcher for the first element of the tuple
+     * @param _2Matcher a matcher for the second element of the tuple
+     * @return A matcher of {@link Tuple2}
+     */
+    public static <_1, _2> Tuple2Matcher<_1, _2> isTuple2That(Matcher<? super _1> _1Matcher,
+                                                              Matcher<? super _2> _2Matcher) {
+        return new Tuple2Matcher<>(_1Matcher, _2Matcher);
+    }
+}

--- a/lambda-matchers/src/test/java/org/movealong/sly/test/lambda/Tuple2MatcherTest.java
+++ b/lambda-matchers/src/test/java/org/movealong/sly/test/lambda/Tuple2MatcherTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.test.lambda;
+
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import org.junit.jupiter.api.Test;
+
+import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.movealong.sly.hamcrest.DescribeMismatch.describeMismatch;
+import static org.movealong.sly.hamcrest.DescriptionOf.descriptionOf;
+import static org.movealong.sly.test.lambda.Tuple2Matcher.isTuple2That;
+
+class Tuple2MatcherTest {
+    @Test
+    void goodMatch() {
+        Tuple2Matcher<String, Integer> sut = isTuple2That(equalTo("first"), equalTo(1));
+
+        assertThat(descriptionOf(sut), equalTo("Tuple of \"first\" and <1>"));
+        assertTrue(sut.matches(tuple("first", 1)));
+    }
+
+    @Test
+    void leadingMismatch() {
+        Tuple2<String, Integer>        item = tuple("first", 1);
+        Tuple2Matcher<String, Integer> sut  = isTuple2That(equalTo("second"), equalTo(1));
+
+        assertFalse(sut.matches(item));
+        assertThat(describeMismatch(sut, item),
+                   equalTo("tuple mismatch: _1: expected \"second\" but was \"first\""));
+    }
+
+    @Test
+    void trailingMismatch() {
+        Tuple2<String, Integer>        item = tuple("first", 1);
+        Tuple2Matcher<String, Integer> sut  = isTuple2That(equalTo("first"), equalTo(2));
+
+        assertFalse(sut.matches(item));
+        assertThat(describeMismatch(sut, item),
+                   equalTo("tuple mismatch: _2: expected <2> but was <1>"));
+    }
+
+    @Test
+    void fullMismatch() {
+        Tuple2<String, Integer>        item = tuple("first", 1);
+        Tuple2Matcher<String, Integer> sut  = isTuple2That(equalTo("second"), equalTo(2));
+
+        assertFalse(sut.matches(item));
+        assertThat(describeMismatch(sut, item),
+                   equalTo("tuple mismatch: _1: expected \"second\" but was \"first\" and _2: expected <2> but was <1>"));
+    }
+}

--- a/lang/src/main/java/org/movealong/sly/lang/hfn/HyperFn.java
+++ b/lang/src/main/java/org/movealong/sly/lang/hfn/HyperFn.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2023 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.lang.hfn;
+
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functor.Functor;
+import com.jnape.palatable.winterbourne.NaturalTransformation;
+
+/**
+ * A <code>HyperFn</code> is an arrow from a {@link Functor} <code>F</code> and
+ * carrier <code>A</code> to a {@link Functor} <code>G</code> and carrier
+ * <code>B</code>. This is strictly more powerful than a
+ * {@link NaturalTransformation}, which has no impact on the carrier type or
+ * value of its input.
+ * <p>
+ * It is similar in nature to a compatible {@link Fn1} with the signature
+ * <code>Fn1&lt;Functor&lt;A, F&gt;, Functor&lt;B, G&gt;&gt;</code>.
+ * The utility of <code>HyperFn</code> over a compatible {@link Fn1} is
+ * contingent on a need to compose them, since the compatible {@link Fn1} form
+ * is sufficient for any other purpose.
+ * <p>
+ * <code>HyperFn</code> is especially useful in cases where the transformation
+ * of the {@link Functor} and carrier are linked. When the transformations are
+ * not connected, then the operation can be expressed as a composition of an
+ * {@link Functor#fmap(Fn1)} operation on the {@link Functor} followed by a
+ * {@link NaturalTransformation}, or vice versa.
+ *
+ * @param <F> the input {@link Functor} type
+ * @param <A> the input carrier type
+ * @param <G> the output {@link Functor} type
+ * @param <B> the output carrier type
+ */
+public interface HyperFn<F extends Functor<?, F>, A, G extends Functor<?, G>, B> {
+
+    <GB extends Functor<B, G>> GB apply(Functor<A, F> fa);
+
+    /**
+     * Left-to-right composition of two compatible <code>HyperFn</code> arrows,
+     * yielding a new <code>HyperFn</code>
+     *
+     * @param hf  the <code>HyperFn</code> to run after this one
+     * @param <H> the ultimate output {@link Functor} type
+     * @param <C> the ultimate output carrier type
+     * @return the composition of the two arrows as a new <code>HyperFn</code>
+     */
+    default <H extends Functor<?, H>, C> HyperFn<F, A, H, C> andThen(HyperFn<G, B, H, C> hf) {
+        return hyperFn(fa -> hf.apply(apply(fa)));
+    }
+
+    /**
+     * Adapt a compatible {@link Fn1} into a <code>HyperFn</code>
+     *
+     * @param fn  the function
+     * @param <F> the input {@link Functor} type
+     * @param <A> the input carrier type
+     * @param <G> the output {@link Functor} type
+     * @param <B> the output carrier type
+     * @return the function adapted as a <code>HyperFn</code>
+     */
+    static <F extends Functor<?, F>, A, G extends Functor<?, G>, B> HyperFn<F, A, G, B>
+    hyperFn(Fn1<Functor<A, F>, ? extends Functor<B, G>> fn) {
+        return new HyperFn<>() {
+            @Override
+            public <GB extends Functor<B, G>> GB apply(Functor<A, F> fa) {
+                return fn.apply(fa).coerce();
+            }
+        };
+    }
+
+    /**
+     * The identity <code>HyperFn</code>.
+     *
+     * @param <F> the {@link Functor} type
+     * @param <A> the carrier type
+     * @return the identity <code>HyperFn</code>
+     */
+    static <F extends Functor<?, F>, A> HyperFn<F, A, F, A> identity() {
+        return hyperFn(Functor::coerce);
+    }
+}

--- a/lang/src/main/java/org/movealong/sly/lang/hfn/JoiningEither.java
+++ b/lang/src/main/java/org/movealong/sly/lang/hfn/JoiningEither.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.lang.hfn;
+
+import com.jnape.palatable.lambda.adt.Either;
+import com.jnape.palatable.lambda.functor.Functor;
+import com.jnape.palatable.lambda.monad.Monad;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.EitherT;
+import lombok.NoArgsConstructor;
+
+import static com.jnape.palatable.lambda.monad.transformer.builtin.EitherT.eitherT;
+import static lombok.AccessLevel.PRIVATE;
+
+@NoArgsConstructor(access = PRIVATE)
+public final class JoiningEither<M extends MonadRec<?, M>, L, R> implements
+    HyperFn<EitherT<M, L, ?>, Either<L, R>, EitherT<M, L, ?>, R> {
+
+    public static final JoiningEither<?, ?, ?> INSTANCE = new JoiningEither<>();
+
+    @Override
+    public <GB extends Functor<R, EitherT<M, L, ?>>> GB apply(Functor<Either<L, R>, EitherT<M, L, ?>> fa) {
+        return eitherT(fa.<EitherT<M, L, Either<L, R>>>coerce().runEitherT().fmap(Monad::join)).coerce();
+    }
+
+    /**
+     * A <code>HyperFn</code> that takes an {@link EitherT} with an
+     * {@link Either} in the carrier and, provided they share a common left
+     * type, joins the <code>Either</code>s.
+     *
+     * @param <M> the argument {@link MonadRec}
+     * @param <L> the left type
+     * @param <R> the right type
+     * @return an interpreter that transforms {@link EitherT}
+     */
+    @SuppressWarnings("unchecked")
+    public static <M extends MonadRec<?, M>, L, R> JoiningEither<M, L, R> joiningEither() {
+        return (JoiningEither<M, L, R>) INSTANCE;
+    }
+}

--- a/lang/src/main/java/org/movealong/sly/lang/hfn/JoiningIdentity.java
+++ b/lang/src/main/java/org/movealong/sly/lang/hfn/JoiningIdentity.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.lang.hfn;
+
+import com.jnape.palatable.lambda.functor.Functor;
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.EitherT;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IdentityT;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@NoArgsConstructor(access = PRIVATE)
+public final class JoiningIdentity<M extends MonadRec<?, M>, A> implements
+    HyperFn<IdentityT<M, ?>, Identity<A>, IdentityT<M, ?>, A> {
+
+    public static final JoiningIdentity<?, ?> INSTANCE = new JoiningIdentity<>();
+
+    @Override
+    public <GB extends Functor<A, IdentityT<M, ?>>> GB apply(Functor<Identity<A>, IdentityT<M, ?>> fa) {
+        return fa.fmap(Identity::runIdentity).coerce();
+    }
+
+    /**
+     * A <code>HyperFn</code> that takes an {@link IdentityT} with an
+     * {@link Identity} in the carrier and joins the <code>Identity</code>
+     * effects.
+     *
+     * @param <M> the argument {@link MonadRec}
+     * @param <A> the carrier type
+     * @return an interpreter that transforms {@link EitherT}
+     */
+    @SuppressWarnings("unchecked")
+    public static <M extends MonadRec<?, M>, A> JoiningIdentity<M, A> joiningIdentity() {
+        return (JoiningIdentity<M, A>) INSTANCE;
+    }
+}

--- a/lang/src/main/java/org/movealong/sly/lang/hfn/JoiningMaybe.java
+++ b/lang/src/main/java/org/movealong/sly/lang/hfn/JoiningMaybe.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.lang.hfn;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.functor.Functor;
+import com.jnape.palatable.lambda.monad.Monad;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.MaybeT;
+
+import static com.jnape.palatable.lambda.monad.transformer.builtin.MaybeT.maybeT;
+
+public class JoiningMaybe<M extends MonadRec<?, M>, A> implements
+    HyperFn<MaybeT<M, ?>, Maybe<A>, MaybeT<M, ?>, A> {
+
+    public static final JoiningMaybe<?, ?> INSTANCE = new JoiningMaybe<>();
+
+    @Override
+    public <GB extends Functor<A, MaybeT<M, ?>>> GB apply(Functor<Maybe<A>, MaybeT<M, ?>> fa) {
+        return maybeT(fa.<MaybeT<M, Maybe<A>>>coerce().runMaybeT().fmap(Monad::join)).coerce();
+    }
+
+    /**
+     * A {@link HyperFn} that takes a {@link MaybeT} with a {@link Maybe} in
+     * the carrier and joins the effects of the <code>Maybe</code> and the
+     * <code>MaybeT</code>.
+     *
+     * @param <M> the argument {@link MonadRec}
+     * @param <A> the carrier type
+     * @return an interpreter that transforms {@link MaybeT}
+     */
+    @SuppressWarnings("unchecked")
+    public static <M extends MonadRec<?, M>, A> JoiningMaybe<M, A> joiningMaybe() {
+        return (JoiningMaybe<M, A>) INSTANCE;
+    }
+}

--- a/lang/src/main/java/org/movealong/sly/lang/hfn/JoiningState.java
+++ b/lang/src/main/java/org/movealong/sly/lang/hfn/JoiningState.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.lang.hfn;
+
+import com.jnape.palatable.lambda.functor.Functor;
+import com.jnape.palatable.lambda.functor.builtin.State;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.EitherT;
+import com.jnape.palatable.lambda.monad.transformer.builtin.StateT;
+import lombok.NoArgsConstructor;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Into.into;
+import static lombok.AccessLevel.PRIVATE;
+
+@NoArgsConstructor(access = PRIVATE)
+public final class JoiningState<S, M extends MonadRec<?, M>, A> implements
+    HyperFn<StateT<S, M, ?>, State<S, A>, StateT<S, M, ?>, A> {
+
+    public static final JoiningState<?, ?, ?> INSTANCE = new JoiningState<>();
+
+    @Override
+    public <GB extends Functor<A, StateT<S, M, ?>>> GB apply(Functor<State<S, A>, StateT<S, M, ?>> fa) {
+        return StateT.<S, M, A>stateT(
+                         s -> fa.<StateT<S, M, State<S, A>>>coerce()
+                                .runStateT(s)
+                                .fmap(into(State::run)))
+                     .coerce();
+    }
+
+    /**
+     * A <code>HyperFn</code> that takes an {@link StateT} with an
+     * {@link State} in the carrier and, provided they share a common state
+     * type, joins the <code>State</code> effectss.
+     *
+     * @param <M> the argument {@link MonadRec}
+     * @param <S> the state type
+     * @param <A> the carrier type
+     * @return an interpreter that transforms {@link EitherT}
+     */
+    @SuppressWarnings("unchecked")
+    public static <S, M extends MonadRec<?, M>, A> JoiningState<S, M, A> joiningState() {
+        return (JoiningState<S, M, A>) INSTANCE;
+    }
+}

--- a/lang/src/main/java/org/movealong/sly/lang/hfn/RunningEitherT.java
+++ b/lang/src/main/java/org/movealong/sly/lang/hfn/RunningEitherT.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.lang.hfn;
+
+import com.jnape.palatable.lambda.adt.Either;
+import com.jnape.palatable.lambda.functor.Functor;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.EitherT;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@NoArgsConstructor(access = PRIVATE)
+public final class RunningEitherT<M extends MonadRec<?, M>, L, R> implements
+    HyperFn<EitherT<M, L, ?>, R, M, Either<L, R>> {
+
+    public static final RunningEitherT<?, ?, ?> INSTANCE = new RunningEitherT<>();
+
+    @Override
+    public <GB extends Functor<Either<L, R>, M>> GB apply(Functor<R, EitherT<M, L, ?>> fa) {
+        return fa.<EitherT<M, L, R>>coerce().runEitherT().coerce();
+    }
+
+    /**
+     * A {@link HyperFn} that runs an {@link EitherT}, producing an instance of
+     * its argument {@link MonadRec} with an {@link Either} as the carrier.
+     *
+     * @param <M> the argument {@link MonadRec}
+     * @param <L> ths left type of the {@link EitherT}
+     * @param <R> the carrier type
+     * @return an interpreter that runs {@link EitherT}
+     */
+    @SuppressWarnings("unchecked")
+    public static <M extends MonadRec<?, M>, L, R> RunningEitherT<M, L, R> runningEitherT() {
+        return (RunningEitherT<M, L, R>) INSTANCE;
+    }
+}

--- a/lang/src/main/java/org/movealong/sly/lang/hfn/RunningIdentityT.java
+++ b/lang/src/main/java/org/movealong/sly/lang/hfn/RunningIdentityT.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.lang.hfn;
+
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IdentityT;
+
+import static org.movealong.sly.lang.hfn.HyperFn.hyperFn;
+
+public class RunningIdentityT {
+    /**
+     * An <code>Interpreter</code> that runs an {@link IdentityT}, producing
+     * an instance of its argument {@link MonadRec} with an {@link Identity} as
+     * the carrier.
+     *
+     * @param <M> the argument {@link MonadRec}
+     * @return an interpreter that runs {@link IdentityT}
+     */
+    public static <M extends MonadRec<?, M>, A> HyperFn<IdentityT<M, ?>, A, M, Identity<A>> runningIdentityT() {
+        return hyperFn(fa -> fa.<IdentityT<M, A>>coerce().runIdentityT());
+    }
+}

--- a/lang/src/main/java/org/movealong/sly/lang/hfn/RunningIterateT.java
+++ b/lang/src/main/java/org/movealong/sly/lang/hfn/RunningIterateT.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.lang.hfn;
+
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functor.Functor;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+import com.jnape.palatable.lambda.monad.transformer.builtin.MaybeT;
+import lombok.NoArgsConstructor;
+
+import static com.jnape.palatable.lambda.monad.transformer.builtin.MaybeT.maybeT;
+import static lombok.AccessLevel.PRIVATE;
+
+@NoArgsConstructor(access = PRIVATE)
+public final class RunningIterateT<M extends MonadRec<?, M>, A> implements
+    HyperFn<IterateT<M, ?>, A, MaybeT<M, ?>, Tuple2<A, IterateT<M, A>>> {
+
+    public static final RunningIterateT<?, ?> INSTANCE = new RunningIterateT<>();
+
+    @Override
+    public <GB extends Functor<Tuple2<A, IterateT<M, A>>, MaybeT<M, ?>>> GB apply(Functor<A, IterateT<M, ?>> fa) {
+        return maybeT(fa.<IterateT<M, A>>coerce().runIterateT()).coerce();
+    }
+
+    /**
+     * A <code>HyperFn</code> that runs an {@link IterateT}, producing an
+     * instance of {@link MaybeT} with the same argument {@link MonadRec}
+     * bearing a tuple of the head and tail of the iteration.
+     *
+     * @param <M> the argument {@link MonadRec}
+     * @return an interpreter that runs {@link IterateT}
+     */
+    @SuppressWarnings("unchecked")
+    public static <M extends MonadRec<?, M>, A> RunningIterateT<M, A> runningIterateT() {
+        return (RunningIterateT<M, A>) INSTANCE;
+    }
+}

--- a/lang/src/main/java/org/movealong/sly/lang/hfn/RunningMaybeT.java
+++ b/lang/src/main/java/org/movealong/sly/lang/hfn/RunningMaybeT.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.lang.hfn;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.functor.Functor;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.MaybeT;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@NoArgsConstructor(access = PRIVATE)
+public final class RunningMaybeT<M extends MonadRec<?, M>, A> implements
+    HyperFn<MaybeT<M, ?>, A, M, Maybe<A>> {
+
+    public static final RunningMaybeT<?, ?> INSTANCE = new RunningMaybeT<>();
+
+    @Override
+    public <GB extends Functor<Maybe<A>, M>> GB apply(Functor<A, MaybeT<M, ?>> fa) {
+        return fa.<MaybeT<M, A>>coerce().runMaybeT().coerce();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <M extends MonadRec<?, M>, A> RunningMaybeT<M, A> runningMaybeT() {
+        return (RunningMaybeT<M, A>) INSTANCE;
+    }
+}

--- a/lang/src/main/java/org/movealong/sly/lang/hfn/RunningStateT.java
+++ b/lang/src/main/java/org/movealong/sly/lang/hfn/RunningStateT.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.lang.hfn;
+
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functor.Functor;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.StateT;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public final class RunningStateT<M extends MonadRec<?, M>, S, A> implements
+    HyperFn<StateT<S, M, ?>, A, M, Tuple2<A, S>> {
+    private final S s;
+
+    @Override
+    public <GB extends Functor<Tuple2<A, S>, M>> GB apply(Functor<A, StateT<S, M, ?>> fa) {
+        return fa.<StateT<S, M, A>>coerce().runStateT(s).coerce();
+    }
+
+    /**
+     * An <code>HyperFn</code> that runs a {@link StateT}, producing an
+     * instance of its argument {@link MonadRec} bearing a tuple of final state
+     * &lt;S&gt; and the original carrier.
+     *
+     * @param <M> the argument {@link MonadRec}
+     * @param <S> the state type
+     * @param s   the initial state
+     * @return a <code>HyperFn</code> that runs {@link StateT}
+     */
+    public static <M extends MonadRec<?, M>, S, A> RunningStateT<M, S, A> runningStateT(S s) {
+        return new RunningStateT<>(s);
+    }
+}

--- a/lang/src/main/java/org/movealong/sly/lang/hfn/RunningStreamT.java
+++ b/lang/src/main/java/org/movealong/sly/lang/hfn/RunningStreamT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.lang.hfn;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functor.Functor;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.MaybeT;
+import com.jnape.palatable.winterbourne.StreamT;
+import lombok.NoArgsConstructor;
+
+import static com.jnape.palatable.lambda.monad.transformer.builtin.MaybeT.maybeT;
+import static lombok.AccessLevel.PRIVATE;
+
+@NoArgsConstructor(access = PRIVATE)
+public final class RunningStreamT<M extends MonadRec<?, M>, A> implements
+    HyperFn<StreamT<M, ?>, A, MaybeT<M, ?>, Tuple2<Maybe<A>, StreamT<M, A>>> {
+
+    public static final RunningStreamT<?, ?> INSTANCE = new RunningStreamT<>();
+
+    @Override
+    public <GB extends Functor<Tuple2<Maybe<A>, StreamT<M, A>>, MaybeT<M, ?>>>
+    GB apply(Functor<A, StreamT<M, ?>> fa) {
+        return maybeT(fa.<StreamT<M, A>>coerce().runStreamT()).coerce();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <M extends MonadRec<?, M>, A>
+    RunningStreamT<M, A> runningStreamT() {
+        return (RunningStreamT<M, A>) INSTANCE;
+    }
+}

--- a/lang/src/test/java/org/movealong/sly/lang/hfn/JoiningEitherTest.java
+++ b/lang/src/test/java/org/movealong/sly/lang/hfn/JoiningEitherTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.lang.hfn;
+
+import com.jnape.palatable.lambda.adt.Either;
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.monad.transformer.builtin.EitherT;
+import org.junit.jupiter.api.Test;
+
+import static com.jnape.palatable.lambda.adt.Either.left;
+import static com.jnape.palatable.lambda.adt.Either.right;
+import static com.jnape.palatable.lambda.adt.Maybe.just;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.EitherT.eitherT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+class JoiningEitherTest {
+    @Test
+    void joiningRight() {
+        EitherT<Maybe<?>, String, Either<String, Integer>> input = eitherT(just(right(right(1))));
+        assertThat(JoiningEither.<Maybe<?>, String, Integer>joiningEither()
+                                .<EitherT<Maybe<?>, String, Integer>>apply(input),
+                   equalTo(eitherT(just(right(1)))));
+    }
+
+    @Test
+    void joiningLeft() {
+        EitherT<Maybe<?>, String, Either<String, Integer>> input = eitherT(just(right(left("no"))));
+        assertThat(JoiningEither.<Maybe<?>, String, Integer>joiningEither()
+                                .<EitherT<Maybe<?>, String, Integer>>apply(input),
+                   equalTo(eitherT(just(left("no")))));
+    }
+}

--- a/lang/src/test/java/org/movealong/sly/lang/hfn/JoiningMaybeTest.java
+++ b/lang/src/test/java/org/movealong/sly/lang/hfn/JoiningMaybeTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.lang.hfn;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.io.IO;
+import com.jnape.palatable.lambda.monad.transformer.builtin.MaybeT;
+import org.junit.jupiter.api.Test;
+
+import static com.jnape.palatable.lambda.adt.Maybe.just;
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.io.IO.io;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.MaybeT.maybeT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.movealong.sly.matchers.lambda.JustMatcher.isJustOf;
+import static testsupport.matchers.IOMatcher.yieldsValue;
+
+class JoiningMaybeTest {
+    @Test
+    void joiningMaybeTJustJust() {
+        assertThat(JoiningMaybe
+                       .<IO<?>, String>joiningMaybe()
+                       .<MaybeT<IO<?>, String>>apply(maybeT(io(just(just("junit")))))
+                       .runMaybeT(),
+                   yieldsValue(isJustOf("junit")));
+    }
+
+    @Test
+    void joiningMaybeTJustNothing() {
+        assertThat(JoiningMaybe
+                       .<IO<?>, String>joiningMaybe()
+                       .<MaybeT<IO<?>, String>>apply(maybeT(io(just(nothing()))))
+                       .<IO<Maybe<String>>>runMaybeT(),
+                   yieldsValue(equalTo(nothing())));
+    }
+
+    @Test
+    void joiningMaybeTNothing() {
+        assertThat(JoiningMaybe
+                       .<IO<?>, String>joiningMaybe()
+                       .<MaybeT<IO<?>, String>>apply(maybeT(io(nothing())))
+                       .<IO<Maybe<String>>>runMaybeT(),
+                   yieldsValue(equalTo(nothing())));
+    }
+}

--- a/lang/src/test/java/org/movealong/sly/lang/hfn/RunningEitherTTest.java
+++ b/lang/src/test/java/org/movealong/sly/lang/hfn/RunningEitherTTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.lang.hfn;
+
+import com.jnape.palatable.lambda.adt.Either;
+import com.jnape.palatable.lambda.io.IO;
+import org.junit.jupiter.api.Test;
+
+import static com.jnape.palatable.lambda.adt.Either.left;
+import static com.jnape.palatable.lambda.adt.Either.right;
+import static com.jnape.palatable.lambda.io.IO.io;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.EitherT.eitherT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static testsupport.matchers.EitherMatcher.isLeftThat;
+import static testsupport.matchers.EitherMatcher.isRightThat;
+import static testsupport.matchers.IOMatcher.yieldsValue;
+
+class RunningEitherTTest {
+    @Test
+    void runningRight() {
+        assertThat(RunningEitherT.<IO<?>, String, Integer>runningEitherT()
+                                 .<IO<Either<String, Integer>>>apply(eitherT(io(right(1)))),
+                   yieldsValue(isRightThat(equalTo(1))));
+    }
+
+    @Test
+    void runningLeft() {
+        assertThat(RunningEitherT.<IO<?>, String, Integer>runningEitherT()
+                                 .<IO<Either<String, Integer>>>apply(eitherT(io(left("no")))),
+                   yieldsValue(isLeftThat(equalTo("no"))));
+    }
+}

--- a/lang/src/test/java/org/movealong/sly/lang/hfn/RunningIdentityTTest.java
+++ b/lang/src/test/java/org/movealong/sly/lang/hfn/RunningIdentityTTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.lang.hfn;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import com.jnape.palatable.lambda.io.IO;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IdentityT;
+import org.junit.jupiter.api.Test;
+
+import static com.jnape.palatable.lambda.adt.Maybe.just;
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.io.IO.io;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IdentityT.identityT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.movealong.sly.lang.hfn.RunningIdentityT.runningIdentityT;
+import static org.movealong.sly.matchers.lambda.JustMatcher.isJustOf;
+import static testsupport.matchers.IOMatcher.yieldsValue;
+
+class RunningIdentityTTest {
+    @Test
+    void runningWithIO() {
+        HyperFn<IdentityT<IO<?>, ?>, String, IO<?>, Identity<String>> sut = runningIdentityT();
+        assertThat(sut.apply(identityT(io(new Identity<>("junit")))),
+                   yieldsValue(equalTo(new Identity<>("junit"))));
+    }
+
+    @Test
+    void runningWithPresentMaybe() {
+        HyperFn<IdentityT<Maybe<?>, ?>, String, Maybe<?>, Identity<String>> sut = runningIdentityT();
+        assertThat(sut.apply(identityT(just(new Identity<>("junit")))),
+                   isJustOf(new Identity<>("junit")));
+    }
+
+    @Test
+    void runningWithAbsentMaybe() {
+        HyperFn<IdentityT<Maybe<?>, ?>, String, Maybe<?>, Identity<String>> sut = runningIdentityT();
+        assertThat(sut.apply(identityT(nothing())),
+                   equalTo(Maybe.<Identity<String>>nothing()));
+    }
+}

--- a/lang/src/test/java/org/movealong/sly/lang/hfn/RunningIterateTTest.java
+++ b/lang/src/test/java/org/movealong/sly/lang/hfn/RunningIterateTTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.lang.hfn;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import com.jnape.palatable.lambda.io.IO;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+import org.junit.jupiter.api.Test;
+
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.io.IO.pureIO;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.empty;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.movealong.sly.lang.hfn.RunningMaybeT.runningMaybeT;
+import static org.movealong.sly.matchers.lambda.JustMatcher.isJustThat;
+import static org.movealong.sly.test.lambda.Tuple2Matcher.isTuple2That;
+import static testsupport.matchers.IOMatcher.yieldsValue;
+import static testsupport.matchers.IterateTMatcher.iterates;
+
+class RunningIterateTTest {
+    @Test
+    void runningIterateTEmpty() {
+        assertThat(RunningIterateT
+                       .<IO<?>, Integer>runningIterateT()
+                       .andThen(runningMaybeT())
+                       .<IO<Maybe<Tuple2<Integer, IterateT<IO<?>, Integer>>>>>apply(empty(pureIO())),
+                   yieldsValue(equalTo(nothing())));
+    }
+
+    @Test
+    void runningIterateTNonEmpty() {
+        IterateT<Identity<?>, Integer> input =
+            IterateT.of(new Identity<>(1),
+                        new Identity<>(1),
+                        new Identity<>(2),
+                        new Identity<>(3),
+                        new Identity<>(5));
+        assertThat(RunningIterateT
+                       .<Identity<?>, Integer>runningIterateT()
+                       .andThen(runningMaybeT())
+                       .<Identity<Maybe<Tuple2<Integer, IterateT<Identity<?>, Integer>>>>>apply(input)
+                       .runIdentity(),
+                   isJustThat(isTuple2That(
+                       equalTo(1),
+                       iterates(1, 2, 3, 5))));
+    }
+}

--- a/lang/src/test/java/org/movealong/sly/lang/hfn/RunningMaybeTTest.java
+++ b/lang/src/test/java/org/movealong/sly/lang/hfn/RunningMaybeTTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.lang.hfn;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.io.IO;
+import org.junit.jupiter.api.Test;
+
+import static com.jnape.palatable.lambda.adt.Maybe.just;
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.io.IO.io;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.MaybeT.maybeT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.movealong.sly.matchers.lambda.JustMatcher.isJustOf;
+import static testsupport.matchers.IOMatcher.yieldsValue;
+
+class RunningMaybeTTest {
+    @Test
+    void runningMaybeTJust() {
+        assertThat(RunningMaybeT
+                       .<IO<?>, String>runningMaybeT()
+                       .apply(maybeT(io(just("junit")))),
+                   yieldsValue(isJustOf("junit")));
+    }
+
+    @Test
+    void runningMaybeTNothing() {
+        assertThat(RunningMaybeT
+                       .<IO<?>, String>runningMaybeT()
+                       .<IO<Maybe<String>>>apply(maybeT(io(nothing()))),
+                   yieldsValue(equalTo(nothing())));
+    }
+}

--- a/lang/src/test/java/org/movealong/sly/lang/hfn/RunningStateTTest.java
+++ b/lang/src/test/java/org/movealong/sly/lang/hfn/RunningStateTTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.lang.hfn;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import org.junit.jupiter.api.Test;
+
+import static com.jnape.palatable.lambda.adt.Maybe.just;
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Empty.empty;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Not.not;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Size.size;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Tail.tail;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Both.both;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.StateT.stateT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.movealong.sly.matchers.lambda.JustMatcher.isJustThat;
+import static org.movealong.sly.model.Stringy.stringify;
+import static org.movealong.sly.model.Stringy.stringy;
+import static org.movealong.sly.test.lambda.Tuple2Matcher.isTuple2That;
+
+class RunningStateTTest {
+    @Test
+    void runningStateTMaybeJust() {
+        assertThat(RunningStateT
+                       .<Maybe<?>, String, Long>runningStateT("junit")
+                       .apply(stateT(s -> just(stringy(s))
+                           .filter(not(empty()))
+                           .fmap(both(size(), sy -> stringify(tail(sy)))))),
+                   isJustThat(isTuple2That(equalTo(5L), equalTo("unit"))));
+    }
+
+    @Test
+    void runningStateTMaybeNothing() {
+        assertThat(RunningStateT
+                       .<Maybe<?>, String, Long>runningStateT("")
+                       .<Maybe<Tuple2<Long, String>>>apply(stateT(s -> just(stringy(s))
+                           .filter(not(empty()))
+                           .fmap(both(size(), sy -> stringify(tail(sy)))))),
+                   equalTo(nothing()));
+    }
+}

--- a/lang/src/test/java/org/movealong/sly/lang/hfn/RunningStreamTTest.java
+++ b/lang/src/test/java/org/movealong/sly/lang/hfn/RunningStreamTTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.lang.hfn;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.io.IO;
+import com.jnape.palatable.lambda.monad.transformer.builtin.MaybeT;
+import com.jnape.palatable.shoki.impl.StrictQueue;
+import com.jnape.palatable.winterbourne.StreamT;
+import org.junit.jupiter.api.Test;
+
+import static com.jnape.palatable.lambda.adt.Maybe.just;
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.io.IO.io;
+import static com.jnape.palatable.shoki.impl.StrictQueue.strictQueue;
+import static com.jnape.palatable.winterbourne.StreamT.streamT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.movealong.sly.matchers.jdk.IterableMatcher.iterates;
+import static org.movealong.sly.matchers.lambda.JustMatcher.isJustOf;
+import static org.movealong.sly.matchers.lambda.JustMatcher.isJustThat;
+import static org.movealong.sly.test.lambda.Tuple2Matcher.isTuple2That;
+import static testsupport.matchers.IOMatcher.yieldsValue;
+
+class RunningStreamTTest {
+    @Test
+    void runningWithIO() {
+        StreamT<IO<?>, Integer> subject = streamT(
+            io(just(1)),
+            io(nothing()),
+            io(just(3)),
+            io(nothing()),
+            io(just(5)),
+            io(nothing()),
+            io(just(7)),
+            io(nothing()),
+            io(just(9)),
+            io(nothing()));
+
+        assertThat(RunningStreamT.<IO<?>, Integer>runningStreamT()
+                                 .<MaybeT<IO<?>, Tuple2<Maybe<Integer>, StreamT<IO<?>, Integer>>>>apply(subject)
+                                 .fmap(t -> t.<IO<StrictQueue<Maybe<Integer>>>>fmap(s -> s
+                                     .fold((q, i) -> io(q.snoc(i)),
+                                           io(strictQueue()))))
+                                 .<IO<Maybe<Tuple2<Maybe<Integer>, IO<StrictQueue<Maybe<Integer>>>>>>>runMaybeT(),
+                   yieldsValue(isJustThat(isTuple2That(
+                       isJustOf(1),
+                       yieldsValue(iterates(
+                           nothing(),
+                           just(3),
+                           nothing(),
+                           just(5),
+                           nothing(),
+                           just(7),
+                           nothing(),
+                           just(9),
+                           nothing()))))));
+    }
+}


### PR DESCRIPTION
Create a new interface HyperFn that expresses a transformation of the form F a -> G b with separate parameterization for all four types. This is sufficiently generic to capture the operation of running an instance of EitherT, in which the Functor transforms from EitherT<M, L, ?> to MonadRec<?, M> and the carrier from R to Either<L, R> and the two transformations are inextricably linked to one another.