### PR TITLE
Get rid of some dead javadoc

### DIFF
--- a/app/src/main/java/org/movealong/sly/app/App.java
+++ b/app/src/main/java/org/movealong/sly/app/App.java
@@ -45,12 +45,6 @@ import static org.movealong.sly.app.Service.serviceRef;
 import static org.movealong.sly.lang.nt.PerformingIO.performingIO;
 import static org.movealong.sly.lang.nt.ThrowingExceptions.throwingExceptions;
 
-/**
- * A
- *
- * @see Service
- * @see ServiceHandle
- */
 @RequiredArgsConstructor(access = PRIVATE)
 public final class App {
     private static final App  INSTANCE = new App(emptyHMap());


### PR DESCRIPTION
Started to write a class-level javadoc but it worked better with method-level only. Forgot to remove the stub.