### PR TITLE
Implement some concurrency primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Important changes in each release of `sly` will be noted in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Added `ConcurrentlyPerformingIO` to `sly-lang`
+- Added `Atom` to `sly-jdk`
+
 ## [0.3.0]
 
 ### Updated

--- a/jdk/src/main/java/org/movealong/sly/jdk/Atom.java
+++ b/jdk/src/main/java/org/movealong/sly/jdk/Atom.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2024 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.jdk;
+
+import com.jnape.palatable.lambda.adt.Unit;
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.io.IO;
+import com.jnape.palatable.lambda.monad.Monad;
+import lombok.AllArgsConstructor;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
+import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
+import static com.jnape.palatable.lambda.io.IO.io;
+import static lombok.AccessLevel.PRIVATE;
+
+/**
+ * An atom is a reference value that can be updated atomically.
+ *
+ * @param <A> The type of object referenced by the atom
+ */
+@AllArgsConstructor(access = PRIVATE)
+public final class Atom<A> {
+    private static final VarHandle HANDLE;
+
+    static {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            HANDLE = lookup.findVarHandle(Atom.class, "a", Object.class);
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private boolean weakCompareAndSet(A prev, A next) {
+        return HANDLE.weakCompareAndSet(this, prev, next);
+    }
+
+    private volatile A a;
+
+    /**
+     * Returns an {@link IO} that will atomically update the current value with
+     * the results of applying the given function, returning a tuple of the
+     * original value and the updated value. When there is contention between
+     * the update and another thread, the update will be retried. This can
+     * happen repeatedly until the update succeeds.
+     *
+     * @param f a function that effectfully produces the next value
+     * @return an {@link IO} that will atomically update the current value
+     */
+    public IO<Tuple2<A, A>> update(Fn1<A, ? extends Monad<A, IO<?>>> f) {
+        return io(() -> {
+            A prev, next;
+            do {
+                prev = a;
+                next = f.apply(prev).<IO<A>>coerce().unsafePerformIO();
+            } while (!weakCompareAndSet(prev, next));
+            return tuple(prev, next);
+        });
+    }
+
+    /**
+     * Returns an {@link IO} that will atomically update the current value with
+     * the results of applying the given function, returning the original
+     * value. When there is contention between the update and another thread,
+     * the update will be retried. This can happen repeatedly until the update
+     * succeeds.
+     *
+     * @param f a function that effectfully produces the next value
+     * @return an {@link IO} that will atomically update the current value
+     */
+    public IO<A> getAndUpdate(Fn1<A, ? extends Monad<A, IO<?>>> f) {
+        return update(f).fmap(Tuple2::_1);
+    }
+
+    /**
+     * Returns an {@link IO} that will atomically update the current value with
+     * the results of applying the given function, returning the updated value.
+     * When there is contention between the update and another thread, the
+     * update will be retried. This can happen repeatedly until the update
+     * succeeds.
+     *
+     * @param f a function that effectfully produces the next value
+     * @return an {@link IO} that will atomically update the current value
+     */
+    public IO<A> updateAndGet(Fn1<A, ? extends Monad<A, IO<?>>> f) {
+        return update(f).fmap(Tuple2::_2);
+    }
+
+    /**
+     * Returns an {@link IO} atomically compares the current value with the
+     * given previous value, and if they are equal, sets the value to the given
+     * next value.
+     *
+     * @param prev the value to compare against
+     * @param next the value to set
+     * @return an {@link IO} that will atomically compare and set the current
+     * value
+     */
+    public IO<Boolean> compareAndSet(A prev, A next) {
+        return io(() -> HANDLE.compareAndSet(this, prev, next));
+    }
+
+    /**
+     * Returns an {@link IO} that will return the current value of the atom
+     * when invoked.
+     *
+     * @return an {@link IO} that will return the current value
+     */
+    public IO<A> get() {
+        return io(() -> a);
+    }
+
+    /**
+     * Return an {@link IO} that will set the value of the atom to the given
+     * value.
+     *
+     * @param a the new value
+     * @return an {@link IO} that will set the value
+     */
+    public IO<Unit> set(A a) {
+        return io(() -> {this.a = a;});
+    }
+
+    /**
+     * Construct an {@link Atom} with the given initial value.
+     *
+     * @param <A> the type that the atom holds
+     * @param a   the initial value
+     * @return an {@link Atom} initialized with the given value
+     */
+    public static <A> Atom<A> atom(A a) {
+        return new Atom<>(a);
+    }
+}

--- a/jdk/src/main/java/org/movealong/sly/jdk/Atom.java
+++ b/jdk/src/main/java/org/movealong/sly/jdk/Atom.java
@@ -58,7 +58,8 @@ public final class Atom<A> {
      * the results of applying the given function, returning a tuple of the
      * original value and the updated value. When there is contention between
      * the update and another thread, the update will be retried. This can
-     * happen repeatedly until the update succeeds.
+     * result in multiple invocations of the given function, as the retries
+     * occur.
      *
      * @param f a function that effectfully produces the next value
      * @return an {@link IO} that will atomically update the current value
@@ -78,8 +79,8 @@ public final class Atom<A> {
      * Returns an {@link IO} that will atomically update the current value with
      * the results of applying the given function, returning the original
      * value. When there is contention between the update and another thread,
-     * the update will be retried. This can happen repeatedly until the update
-     * succeeds.
+     * the update will be retried. This can result in multiple invocations of
+     * the given function, as the retries occur.
      *
      * @param f a function that effectfully produces the next value
      * @return an {@link IO} that will atomically update the current value
@@ -92,8 +93,8 @@ public final class Atom<A> {
      * Returns an {@link IO} that will atomically update the current value with
      * the results of applying the given function, returning the updated value.
      * When there is contention between the update and another thread, the
-     * update will be retried. This can happen repeatedly until the update
-     * succeeds.
+     * update will be retried. This can result in multiple invocations of the
+     * given function, as the retries occur.
      *
      * @param f a function that effectfully produces the next value
      * @return an {@link IO} that will atomically update the current value
@@ -103,17 +104,17 @@ public final class Atom<A> {
     }
 
     /**
-     * Returns an {@link IO} atomically compares the current value with the
-     * given previous value, and if they are equal, sets the value to the given
-     * next value.
+     * Returns an {@link IO} that will atomically compare the current value
+     * with the given previous value, and if they are equal, sets the value to
+     * the given next value.
      *
-     * @param prev the value to compare against
-     * @param next the value to set
+     * @param previous the value to compare against
+     * @param next     the value to set
      * @return an {@link IO} that will atomically compare and set the current
      * value
      */
-    public IO<Boolean> compareAndSet(A prev, A next) {
-        return io(() -> HANDLE.compareAndSet(this, prev, next));
+    public IO<Boolean> compareAndSet(A previous, A next) {
+        return io(() -> HANDLE.compareAndSet(this, previous, next));
     }
 
     /**
@@ -128,7 +129,7 @@ public final class Atom<A> {
 
     /**
      * Return an {@link IO} that will set the value of the atom to the given
-     * value.
+     * value when invoked.
      *
      * @param a the new value
      * @return an {@link IO} that will set the value

--- a/jdk/src/test/java/org/movealong/sly/concurrency/AtomTest.java
+++ b/jdk/src/test/java/org/movealong/sly/concurrency/AtomTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.concurrency;
+
+import com.jnape.palatable.lambda.adt.hlist.HList;
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.io.IO;
+import org.junit.jupiter.api.Test;
+import org.movealong.sly.jdk.Atom;
+
+import java.util.concurrent.ExecutorService;
+
+import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
+import static com.jnape.palatable.lambda.functions.Fn2.fn2;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Sort.sort;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Iterate.iterate;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Replicate.replicate;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Sequence.sequence;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Take.take;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.movealong.sly.jdk.Atom.atom;
+import static org.movealong.sly.matchers.jdk.IterableMatcher.iteratesAll;
+import static testsupport.matchers.IOMatcher.yieldsValue;
+
+class AtomTest {
+
+    @Test
+    void basicGetAndSet() {
+        Atom<String> atom = atom("first");
+        assertThat(atom.get(), yieldsValue(equalTo("first")));
+        atom.set("second").unsafePerformIO();
+        assertThat(atom.get(), yieldsValue(equalTo("second")));
+    }
+
+    @Test
+    void multipleGet() {
+        Atom<String> atom = atom("value");
+        assertThat(atom.get().zip(atom.get().fmap(fn2(HList::tuple))),
+                   yieldsValue(equalTo(tuple("value", "value"))));
+    }
+
+    @Test
+    void parallelUpdates() throws Exception {
+        final int             count    = 500_000;
+        ExecutorService       executor = newCachedThreadPool();
+        Fn1<Integer, Integer> inc      = i -> i + 1;
+
+        Atom<Integer> atom  = atom(0);
+        IO<Integer>   incUp = atom.update(inc.fmap(IO::io)).fmap(Tuple2::_1);
+
+        assertThat(sequence(replicate(count, incUp), IO::io)
+                       .fmap(sort())
+                       .unsafePerformAsyncIO(executor)
+                       .get(),
+                   iteratesAll(take(count, iterate(inc, 0))));
+
+        executor.shutdown();
+    }
+}

--- a/lang/src/main/java/org/movealong/sly/lang/nt/ConcurrentlyPerformingIO.java
+++ b/lang/src/main/java/org/movealong/sly/lang/nt/ConcurrentlyPerformingIO.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2024 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.lang.nt;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.adt.Try;
+import com.jnape.palatable.lambda.functor.Functor;
+import com.jnape.palatable.lambda.io.IO;
+import com.jnape.palatable.winterbourne.NaturalTransformation;
+import lombok.AllArgsConstructor;
+
+import java.time.Duration;
+import java.util.concurrent.Executor;
+
+import static com.jnape.palatable.lambda.adt.Maybe.just;
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.adt.Try.success;
+import static com.jnape.palatable.lambda.adt.Try.trying;
+import static com.jnape.palatable.lambda.functions.Fn0.fn0;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static lombok.AccessLevel.PRIVATE;
+
+/**
+ * A {@link NaturalTransformation} that concurrently runs an {@link IO} safely,
+ * capturing the result of performing the operation as a {@link Try}. An
+ * {@link IO} that yields a result will produce a {@link Try} in the success
+ * state, and an {@link IO} that throws an exception will result in a
+ * {@link Try} in the failure state. The {@link IO} will be run asynchronously
+ * and awaited in order to achieve concurrency.
+ */
+@AllArgsConstructor(access = PRIVATE)
+public final class ConcurrentlyPerformingIO implements NaturalTransformation<IO<?>, Try<?>> {
+
+    private final Maybe<Executor> executor;
+    private final Maybe<Duration> timeout;
+
+    @Override
+    public <A, GA extends Functor<A, Try<?>>> GA apply(Functor<A, IO<?>> fa) {
+        return success(executor.match(
+            fn0(() -> fa.<IO<A>>coerce().unsafePerformAsyncIO()),
+            e -> fa.<IO<A>>coerce().unsafePerformAsyncIO(e)))
+            .flatMap(future -> trying(() -> timeout.match(
+                fn0(future::get),
+                to -> future.get(to.toMillis(), MILLISECONDS))))
+            .coerce();
+    }
+
+    /**
+     * Constructs a {@link ConcurrentlyPerformingIO} that performs an
+     * {@link IO} concurrently, capturing the result of the operation as a
+     * {@link Try}. The {@link IO} will run in the forkjoin pool, and will
+     * not time out.
+     *
+     * @return a {@link ConcurrentlyPerformingIO}
+     */
+    public static ConcurrentlyPerformingIO concurrentlyPerformingIO() {
+        return new ConcurrentlyPerformingIO(nothing(), nothing());
+    }
+
+    /**
+     * Constructs a {@link ConcurrentlyPerformingIO} that performs an {@link IO}
+     * concurrently, capturing the result of the operation as a {@link Try}.
+     * The {@link IO} will run in the supplied {@link Executor}, and will not
+     * time out.
+     *
+     * @param executor the executor to use
+     * @return a {@link ConcurrentlyPerformingIO}
+     */
+    public static ConcurrentlyPerformingIO concurrentlyPerformingIO(Executor executor) {
+        return new ConcurrentlyPerformingIO(just(executor), nothing());
+    }
+
+    /**
+     * Constructs a {@link ConcurrentlyPerformingIO} that performs an {@link IO}
+     * concurrently, capturing the result of the operation as a {@link Try}.
+     * The {@link IO} will run in the forkjoin pool, and will time out after
+     * the supplied {@link Duration}.
+     *
+     * @param timeout the timeout
+     * @return a {@link ConcurrentlyPerformingIO}
+     */
+    public static ConcurrentlyPerformingIO concurrentlyPerformingIO(Duration timeout) {
+        return new ConcurrentlyPerformingIO(nothing(), just(timeout));
+    }
+
+    /**
+     * Constructs a {@link ConcurrentlyPerformingIO} that performs an {@link IO}
+     * concurrently, capturing the result of the operation as a {@link Try}.
+     * The {@link IO} will run in the supplied {@link Executor}, and will time
+     * out after the supplied {@link Duration}.
+     *
+     * @param executor the executor to use
+     * @param timeout  the timeout
+     * @return a {@link ConcurrentlyPerformingIO}
+     */
+    public static ConcurrentlyPerformingIO concurrentlyPerformingIO(Executor executor, Duration timeout) {
+        return new ConcurrentlyPerformingIO(just(executor), just(timeout));
+    }
+}

--- a/lang/src/main/java/org/movealong/sly/lang/nt/ConcurrentlyPerformingIO.java
+++ b/lang/src/main/java/org/movealong/sly/lang/nt/ConcurrentlyPerformingIO.java
@@ -17,12 +17,14 @@ package org.movealong.sly.lang.nt;
 
 import com.jnape.palatable.lambda.adt.Maybe;
 import com.jnape.palatable.lambda.adt.Try;
+import com.jnape.palatable.lambda.functions.Fn1;
 import com.jnape.palatable.lambda.functor.Functor;
 import com.jnape.palatable.lambda.io.IO;
 import com.jnape.palatable.winterbourne.NaturalTransformation;
 import lombok.AllArgsConstructor;
 
 import java.time.Duration;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 
 import static com.jnape.palatable.lambda.adt.Maybe.just;
@@ -30,16 +32,19 @@ import static com.jnape.palatable.lambda.adt.Maybe.nothing;
 import static com.jnape.palatable.lambda.adt.Try.success;
 import static com.jnape.palatable.lambda.adt.Try.trying;
 import static com.jnape.palatable.lambda.functions.Fn0.fn0;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Id.id;
+import static com.jnape.palatable.lambda.functions.builtin.fn4.IfThenElse.ifThenElse;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static lombok.AccessLevel.PRIVATE;
 
 /**
- * A {@link NaturalTransformation} that concurrently runs an {@link IO} safely,
- * capturing the result of performing the operation as a {@link Try}. An
- * {@link IO} that yields a result will produce a {@link Try} in the success
- * state, and an {@link IO} that throws an exception will result in a
- * {@link Try} in the failure state. The {@link IO} will be run asynchronously
- * and awaited in order to achieve concurrency.
+ * A {@link NaturalTransformation} that runs an {@link IO} safely and
+ * concurrently, capturing the result of performing the operation as a
+ * {@link Try}. Applying this transformation to an {@link IO} that yields a
+ * result will produce a {@link Try} in the success state, and applying it to
+ * an {@link IO} that throws an exception will result in a {@link Try} in the
+ * failure state. The transformation will run the {@link IO} asynchronously and
+ * await its completion before returning with an optional timeout.
  */
 @AllArgsConstructor(access = PRIVATE)
 public final class ConcurrentlyPerformingIO implements NaturalTransformation<IO<?>, Try<?>> {
@@ -55,7 +60,14 @@ public final class ConcurrentlyPerformingIO implements NaturalTransformation<IO<
             .flatMap(future -> trying(() -> timeout.match(
                 fn0(future::get),
                 to -> future.get(to.toMillis(), MILLISECONDS))))
+            .catchError(unwrap(ExecutionException.class).fmap(Try::failure))
             .coerce();
+    }
+
+    private Fn1<Throwable, Throwable> unwrap(Class<? extends Throwable> exType) {
+        return ifThenElse(exType::isInstance,
+                          Throwable::getCause,
+                          id());
     }
 
     /**
@@ -86,8 +98,10 @@ public final class ConcurrentlyPerformingIO implements NaturalTransformation<IO<
     /**
      * Constructs a {@link ConcurrentlyPerformingIO} that performs an {@link IO}
      * concurrently, capturing the result of the operation as a {@link Try}.
-     * The {@link IO} will run in the forkjoin pool, and will time out after
-     * the supplied {@link Duration}.
+     * The {@link IO} will run in the forkjoin pool, and the invoking thread
+     * will time out after the supplied {@link Duration}. In the event that a
+     * timeout occurs, the {@link IO} will continue to run asynchronously to
+     * completion.
      *
      * @param timeout the timeout
      * @return a {@link ConcurrentlyPerformingIO}
@@ -97,10 +111,12 @@ public final class ConcurrentlyPerformingIO implements NaturalTransformation<IO<
     }
 
     /**
-     * Constructs a {@link ConcurrentlyPerformingIO} that performs an {@link IO}
-     * concurrently, capturing the result of the operation as a {@link Try}.
-     * The {@link IO} will run in the supplied {@link Executor}, and will time
-     * out after the supplied {@link Duration}.
+     * Constructs a {@link ConcurrentlyPerformingIO} that performs an
+     * {@link IO} concurrently, capturing the result of the operation as a
+     * {@link Try}. The {@link IO} will run in the supplied {@link Executor},
+     * and will time out after the supplied {@link Duration}. In the event that
+     * a timeout occurs, the {@link IO} will continue to run asynchronously to
+     * completion.
      *
      * @param executor the executor to use
      * @param timeout  the timeout

--- a/lang/src/test/java/org/movealong/sly/lang/nt/ConcurrentlyPerformingIOTest.java
+++ b/lang/src/test/java/org/movealong/sly/lang/nt/ConcurrentlyPerformingIOTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.lang.nt;
+
+import com.jnape.palatable.lambda.adt.Try;
+import org.junit.jupiter.api.Test;
+
+import static com.jnape.palatable.lambda.io.IO.throwing;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.movealong.sly.lang.nt.ConcurrentlyPerformingIO.concurrentlyPerformingIO;
+import static org.movealong.sly.matchers.lambda.TryMatcher.failedTryThat;
+
+class ConcurrentlyPerformingIOTest {
+
+    static class TestException extends RuntimeException {}
+
+    @Test
+    void unwrapsExceptions() {
+        assertThat(concurrentlyPerformingIO()
+                       .<String, Try<String>>apply(throwing(new TestException())),
+                   failedTryThat(instanceOf(TestException.class)));
+    }
+}


### PR DESCRIPTION
- Atom captures a reference value that can then be updated atomically
- ConcurrentlyPerformingIO performs IO concurrently by awaiting the asynchronous result of running it in a thread pool