### PR TITLE
feat: Exception matchers

### DIFF
--- a/jdk-matchers/src/main/java/org/movealong/sly/matchers/jdk/ThrowableCauseMatcher.java
+++ b/jdk-matchers/src/main/java/org/movealong/sly/matchers/jdk/ThrowableCauseMatcher.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.matchers.jdk;
+
+import lombok.RequiredArgsConstructor;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import static lombok.AccessLevel.PRIVATE;
+
+/**
+ * Match a {@link Throwable} by its cause.
+ */
+@RequiredArgsConstructor(access = PRIVATE)
+public class ThrowableCauseMatcher extends TypeSafeDiagnosingMatcher<Throwable> {
+
+    private final Matcher<? super Throwable> causeMatcher;
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("exception with cause ")
+                   .appendDescriptionOf(causeMatcher);
+    }
+
+    @Override
+    protected boolean matchesSafely(Throwable item, Description mismatchDescription) {
+        boolean result = causeMatcher.matches(item.getCause());
+        if (!result) {
+            mismatchDescription
+                .appendText("cause ")
+                .appendDescriptionOf(d -> causeMatcher.describeMismatch(item.getCause(), d));
+        }
+
+        return result;
+    }
+
+    /**
+     * Creates a matcher that matches when the examined {@link Throwable} has a cause
+     * that satisfies the specified matcher.
+     *
+     * @param matcher the matcher to apply to the cause of the examined {@link Throwable}
+     * @return a matcher that matches when the examined throwable has a cause that satisfies the specified matcher
+     */
+    public static Matcher<Throwable> hasCauseThat(Matcher<? super Throwable> matcher) {
+        return new ThrowableCauseMatcher(matcher);
+    }
+}

--- a/jdk-matchers/src/main/java/org/movealong/sly/matchers/jdk/ThrowableEventuallyMatcher.java
+++ b/jdk-matchers/src/main/java/org/movealong/sly/matchers/jdk/ThrowableEventuallyMatcher.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.matchers.jdk;
+
+import lombok.RequiredArgsConstructor;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import static lombok.AccessLevel.PRIVATE;
+
+/**
+ * Match a {@link Throwable} by recursively checking its causal chain.
+ * The matcher will return true if any throwable in the causal chain matches the delegate matcher.
+ */
+@RequiredArgsConstructor(access = PRIVATE)
+public class ThrowableEventuallyMatcher extends TypeSafeDiagnosingMatcher<Throwable> {
+
+    private final Matcher<? super Throwable> delegate;
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("exception with a causal chain containing ")
+                   .appendDescriptionOf(delegate);
+    }
+
+    @Override
+    protected boolean matchesSafely(Throwable item, Description mismatchDescription) {
+        if (item == null) {
+            mismatchDescription.appendText("was null");
+            return false;
+        }
+
+        Throwable current = item;
+        while (current != null) {
+            if (delegate.matches(current)) {
+                return true;
+            }
+
+            // Move to the next cause
+            current = current.getCause();
+            if (current == item) {
+                // Handle circular references
+                break;
+            }
+        }
+
+        // If we get here, no throwable in the chain matched
+        mismatchDescription.appendText("no throwable in causal chain matched the delegate matcher");
+
+        return false;
+    }
+
+    /**
+     * Creates a matcher that matches when any throwable in the causal chain of the examined {@link Throwable}
+     * satisfies the specified matcher.
+     *
+     * @param matcher the matcher to apply to each throwable in the causal chain of the examined {@link Throwable}
+     * @return a matcher that matches when any throwable in the causal chain satisfies the specified matcher
+     */
+    public static Matcher<Throwable> hasEventualCauseThat(Matcher<? super Throwable> matcher) {
+        return new ThrowableEventuallyMatcher(matcher);
+    }
+}

--- a/jdk-matchers/src/main/java/org/movealong/sly/matchers/jdk/ThrowableMessageMatcher.java
+++ b/jdk-matchers/src/main/java/org/movealong/sly/matchers/jdk/ThrowableMessageMatcher.java
@@ -23,6 +23,9 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 import static lombok.AccessLevel.PRIVATE;
 import static org.hamcrest.core.IsEqual.equalTo;
 
+/**
+ * Match a {@link Throwable} by its message.
+ */
 @AllArgsConstructor(access = PRIVATE)
 public class ThrowableMessageMatcher extends TypeSafeDiagnosingMatcher<Throwable> {
 
@@ -46,10 +49,24 @@ public class ThrowableMessageMatcher extends TypeSafeDiagnosingMatcher<Throwable
         return result;
     }
 
+    /**
+     * Creates a matcher that matches when the examined {@link Throwable} has a message
+     * that satisfies the specified matcher.
+     *
+     * @param messageMatcher the matcher to apply to the message of the examined {@link Throwable}
+     * @return a matcher that matches when the examined throwable has a message that satisfies the specified matcher
+     */
     public static Matcher<Throwable> hasMessageThat(Matcher<? super CharSequence> messageMatcher) {
         return new ThrowableMessageMatcher(messageMatcher);
     }
 
+    /**
+     * Creates a matcher that matches when the examined {@link Throwable} has a message
+     * that is equal to the specified string.
+     *
+     * @param message the string that the examined throwable's message is expected to equal
+     * @return a matcher that matches when the examined throwable has a message equal to the specified string
+     */
     public static Matcher<Throwable> hasMessageOf(String message) {
         return hasMessageThat(equalTo(message));
     }

--- a/jdk-matchers/src/main/java/org/movealong/sly/matchers/jdk/ThrowableMessageMatcher.java
+++ b/jdk-matchers/src/main/java/org/movealong/sly/matchers/jdk/ThrowableMessageMatcher.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.matchers.jdk;
+
+import lombok.AllArgsConstructor;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import static lombok.AccessLevel.PRIVATE;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+@AllArgsConstructor(access = PRIVATE)
+public class ThrowableMessageMatcher extends TypeSafeDiagnosingMatcher<Throwable> {
+
+    private final Matcher<? super CharSequence> messageMatcher;
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("exception with message ")
+                   .appendDescriptionOf(messageMatcher);
+    }
+
+    @Override
+    protected boolean matchesSafely(Throwable item, Description mismatchDescription) {
+        boolean result = messageMatcher.matches(item.getMessage());
+        if (!result) {
+            mismatchDescription
+                .appendText("message ")
+                .appendDescriptionOf(d -> messageMatcher.describeMismatch(item.getMessage(), d));
+        }
+
+        return result;
+    }
+
+    public static Matcher<Throwable> hasMessageThat(Matcher<? super CharSequence> messageMatcher) {
+        return new ThrowableMessageMatcher(messageMatcher);
+    }
+
+    public static Matcher<Throwable> hasMessageOf(String message) {
+        return hasMessageThat(equalTo(message));
+    }
+}

--- a/jdk-matchers/src/test/java/org/movealong/sly/matchers/jdk/ThrowableCauseMatcherTest.java
+++ b/jdk-matchers/src/test/java/org/movealong/sly/matchers/jdk/ThrowableCauseMatcherTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.matchers.jdk;
+
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.movealong.sly.hamcrest.DescribeMismatch.describeMismatch;
+import static org.movealong.sly.hamcrest.DescriptionOf.descriptionOf;
+import static org.movealong.sly.matchers.jdk.ThrowableCauseMatcher.hasCauseThat;
+import static org.movealong.sly.matchers.jdk.ThrowableMessageMatcher.hasMessageOf;
+
+class ThrowableCauseMatcherTest {
+
+    @Test
+    void matches() {
+        Matcher<Throwable> matcher = hasCauseThat(hasMessageOf("bad happens"));
+        RuntimeException   subject = new RuntimeException("outer", new RuntimeException("bad happens"));
+        assertTrue(matcher.matches(subject));
+    }
+
+    @Test
+    void describesWell() {
+        assertThat(descriptionOf(hasCauseThat(hasMessageOf("bad happens"))),
+                   equalTo("exception with cause exception with message \"bad happens\""));
+    }
+
+    @Test
+    void describesMismatchWell() {
+        Matcher<Throwable> matcher = hasCauseThat(hasMessageOf("bad happens"));
+        RuntimeException   subject = new RuntimeException("outer", new RuntimeException("nothing good"));
+        assertFalse(matcher.matches(subject));
+        assertThat(describeMismatch(matcher, subject),
+                   equalTo("cause message was \"nothing good\""));
+    }
+}

--- a/jdk-matchers/src/test/java/org/movealong/sly/matchers/jdk/ThrowableEventuallyMatcherTest.java
+++ b/jdk-matchers/src/test/java/org/movealong/sly/matchers/jdk/ThrowableEventuallyMatcherTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2025 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.matchers.jdk;
+
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.movealong.sly.hamcrest.DescribeMismatch.describeMismatch;
+import static org.movealong.sly.hamcrest.DescriptionOf.descriptionOf;
+import static org.movealong.sly.matchers.jdk.ThrowableEventuallyMatcher.hasEventualCauseThat;
+import static org.movealong.sly.matchers.jdk.ThrowableMessageMatcher.hasMessageOf;
+
+class ThrowableEventuallyMatcherTest {
+
+    @Test
+    void matchesDirectly() {
+        Matcher<Throwable> matcher = hasEventualCauseThat(hasMessageOf("direct match"));
+        RuntimeException   subject = new RuntimeException("direct match");
+        assertTrue(matcher.matches(subject));
+    }
+
+    @Test
+    void matchesInCausalChain() {
+        Matcher<Throwable> matcher   = hasEventualCauseThat(hasMessageOf("nested match"));
+        RuntimeException   innermost = new RuntimeException("nested match");
+        RuntimeException   middle    = new RuntimeException("middle", innermost);
+        RuntimeException   outer     = new RuntimeException("outer", middle);
+        assertTrue(matcher.matches(outer));
+    }
+
+    @Test
+    void doesNotMatchWhenNoMatchInChain() {
+        Matcher<Throwable> matcher   = hasEventualCauseThat(hasMessageOf("not found"));
+        RuntimeException   innermost = new RuntimeException("innermost");
+        RuntimeException   middle    = new RuntimeException("middle", innermost);
+        RuntimeException   outer     = new RuntimeException("outer", middle);
+        assertFalse(matcher.matches(outer));
+    }
+
+    @Test
+    void describesWell() {
+        assertThat(descriptionOf(hasEventualCauseThat(hasMessageOf("expected message"))),
+                   equalTo("exception with a causal chain containing exception with message \"expected message\""));
+    }
+
+    @Test
+    void describesMismatchWell() {
+        Matcher<Throwable> matcher   = hasEventualCauseThat(hasMessageOf("not found"));
+        RuntimeException   innermost = new RuntimeException("innermost");
+        RuntimeException   middle    = new RuntimeException("middle", innermost);
+        RuntimeException   outer     = new RuntimeException("outer", middle);
+        assertFalse(matcher.matches(outer));
+        assertThat(describeMismatch(matcher, outer),
+                   equalTo("no throwable in causal chain matched the delegate matcher"));
+    }
+
+    @Test
+    void handlesNullThrowable() {
+        Matcher<Throwable> matcher = hasEventualCauseThat(hasMessageOf("any"));
+        assertFalse(matcher.matches(null));
+        assertThat(describeMismatch(matcher, null),
+                   equalTo("was null"));
+    }
+
+    @Test
+    void handlesDeepCausalChain() {
+        Matcher<Throwable> matcher = hasEventualCauseThat(hasMessageOf("deep match"));
+
+        // Create a deep chain of exceptions
+        RuntimeException deepest = new RuntimeException("deep match");
+        RuntimeException level4  = new RuntimeException("level4", deepest);
+        RuntimeException level3  = new RuntimeException("level3", level4);
+        RuntimeException level2  = new RuntimeException("level2", level3);
+        RuntimeException level1  = new RuntimeException("level1", level2);
+
+        assertTrue(matcher.matches(level1));
+    }
+}

--- a/jdk-matchers/src/test/java/org/movealong/sly/matchers/jdk/ThrowableMessageMatcherTest.java
+++ b/jdk-matchers/src/test/java/org/movealong/sly/matchers/jdk/ThrowableMessageMatcherTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Nate Riffe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.movealong.sly.matchers.jdk;
+
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.movealong.sly.hamcrest.DescribeMismatch.describeMismatch;
+import static org.movealong.sly.hamcrest.DescriptionOf.descriptionOf;
+import static org.movealong.sly.matchers.jdk.ThrowableMessageMatcher.hasMessageOf;
+
+class ThrowableMessageMatcherTest {
+
+    @Test
+    void matches() {
+        assertTrue(hasMessageOf("bad happens").matches(new RuntimeException("bad happens")));
+    }
+
+    @Test
+    void describesWell() {
+        assertThat(descriptionOf(hasMessageOf("bad happens")),
+                   equalTo("exception with message \"bad happens\""));
+    }
+
+    @Test
+    void describesMismatchWell() {
+        Matcher<Throwable> matcher = hasMessageOf("bad happens");
+        RuntimeException   subject = new RuntimeException("nothing good");
+        assertFalse(matcher.matches(subject));
+        assertThat(describeMismatch(matcher, subject),
+                   equalTo("message was \"nothing good\""));
+    }
+}


### PR DESCRIPTION
- Reimplement some matchers that used to exist in Junit 4 but have been removed from later versions
- ThrowableMessageMatcher matches Throwable using a delegate to match its message
- ThrowableCauseMatcher matches Throwable using a delegate to match its cause
- ThrowableEventuallyMatcher matches Throwable using a delegate to find a matching cause anywhere in the causal chain