### PR TITLE
feat: auto-fix parent versions in multi-module release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,41 @@ jobs:
     steps:
       - name: Run release-please
         uses: googleapis/release-please-action@v4
+        id: release-please
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Checkout PR branch
+        if: ${{ steps.release-please.outputs.pr && !steps.release-please.outputs.releases_created }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.release-please.outputs.pr_head_ref }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+      - name: Set up JDK 11
+        if: ${{ steps.release-please.outputs.pr && !steps.release-please.outputs.releases_created }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '11'
+          cache: 'maven'
+
+      - name: Fix multi-module parent versions
+        if: ${{ steps.release-please.outputs.pr && !steps.release-please.outputs.releases_created }}
+        run: |
+          # Get version from root pom
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+
+          # Update all module versions consistently
+          mvn versions:set -DnewVersion=$VERSION -DprocessAllModules -DgenerateBackupPoms=false
+
+          # Check if there are changes
+          if ! git diff --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "fix: update parent version references in child modules"
+            git push
+          fi


### PR DESCRIPTION
## Summary
Automate parent version fixes for multi-module Maven projects in release PRs.

## Problem
Release-please's Maven support updates module versions but doesn't update `<parent><version>` references in child pom.xml files, causing build failures.

## Solution
New workflow that:
1. Triggers when release-please creates a release PR (not SNAPSHOT)
2. Runs `mvn versions:set -DprocessAllModules` to ensure all versions are consistent
3. Commits and pushes the fix automatically

## Benefits
- No manual intervention needed for multi-module releases
- Uses Maven Versions Plugin for reliable updates
- Only runs on actual release PRs, not SNAPSHOT bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)