### PR TITLE
feat: create separate workflow to fix multi-module release PRs

### DIFF
--- a/.github/workflows/fix-release-pr.yml
+++ b/.github/workflows/fix-release-pr.yml
@@ -1,0 +1,58 @@
+name: Fix Release PR
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  fix-parent-versions:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      startsWith(github.event.pull_request.title, 'chore(main): release') &&
+      !endsWith(github.event.pull_request.title, '-SNAPSHOT')
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '11'
+          cache: 'maven'
+
+      - name: Get version from root pom
+        id: version
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update all module versions consistently
+        run: |
+          mvn versions:set -DnewVersion=${{ steps.version.outputs.version }} -DprocessAllModules -DgenerateBackupPoms=false
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push if changes
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "fix: update parent version references in child modules"
+          git push


### PR DESCRIPTION
## Summary
Create separate workflow for fixing multi-module Maven parent versions.

## Problem
The combined approach only runs when release-please creates a PR, not when it updates an existing one. When release-please force-pushes to update a PR (e.g., after configuration changes), the fix doesn't run.

## Solution
Separate workflow that triggers on:
- `pull_request: [opened]` - when PR is first created
- `pull_request: [synchronize]` - when PR is updated (including force-pushes)

This ensures parent versions are fixed both initially and after any updates from release-please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)