### PR TITLE
fix: check branch name instead of PR author in fix-release-pr

### DIFF
--- a/.github/workflows/fix-release-pr.yml
+++ b/.github/workflows/fix-release-pr.yml
@@ -8,7 +8,7 @@ jobs:
   fix-parent-versions:
     runs-on: ubuntu-latest
     if: |
-      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      startsWith(github.event.pull_request.head.ref, 'release-please--') &&
       startsWith(github.event.pull_request.title, 'chore(main): release') &&
       !endsWith(github.event.pull_request.title, '-SNAPSHOT')
 


### PR DESCRIPTION
## Problem
The Fix Release PR workflow was being skipped because when using a PAT (RELEASE_PLEASE_TOKEN), release-please creates PRs as the token owner, not as github-actions[bot].

## Solution
Check the branch name pattern (`release-please--*`) instead of the PR author. Release-please uses a consistent branch naming pattern that we can rely on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)