### PR TITLE
fix: extract version from pom.xml without using Maven

### DIFF
--- a/.github/workflows/fix-release-pr.yml
+++ b/.github/workflows/fix-release-pr.yml
@@ -32,11 +32,14 @@ jobs:
       - name: Get version from root pom
         id: version
         run: |
-          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          # Extract version directly from pom.xml without using Maven
+          # (Maven might fail if child modules reference broken parent versions)
+          VERSION=$(grep -m 1 '<version>' pom.xml | sed 's/.*<version>\(.*\)<\/version>.*/\1/' | tr -d ' ')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Update all module versions consistently
         run: |
+          # This will fix parent version references in child modules
           mvn versions:set -DnewVersion=${{ steps.version.outputs.version }} -DprocessAllModules -DgenerateBackupPoms=false
 
       - name: Check for changes


### PR DESCRIPTION
## Problem
Fix Release PR workflow fails when trying to run `mvn help:evaluate` because Maven can't start when child modules reference non-existent parent versions.

## Solution
Extract the version directly from the root pom.xml file using grep/sed instead of using Maven. This works even when the project is in a broken state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)