### PR TITLE
sec: add environment protection to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: production
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Adds `environment: production` to the deploy workflow job
- Prevents rogue workflows from accessing deployment secrets

## Why
A malicious collaborator could create a PR with a rogue workflow that attempts to exfiltrate secrets. By using GitHub environment protection, deployment secrets are isolated and can only be accessed by the designated deploy.yml workflow.

## Required Configuration
After merging this PR, you need to:

1. Navigate to repository Settings → Environments
2. Create a new environment named `production`
3. Move the following secrets from repository secrets to environment secrets:
   - `GPG_PRIVATE_KEY`
   - `GPG_PASSPHRASE`
   - `CENTRAL_USERNAME`
   - `CENTRAL_PASSWORD`
4. Optionally enable "Required reviewers" for manual approval before deployments

The `RELEASE_PLEASE_TOKEN` should remain as a repository secret (not environment secret).

## Test plan
- [ ] Merge this PR
- [ ] Configure production environment with secrets
- [ ] Verify next release deployment works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)